### PR TITLE
allow generation of segwit addresses offline

### DIFF
--- a/ArmoryQt.py
+++ b/ArmoryQt.py
@@ -253,6 +253,9 @@ class ArmoryMainWindow(QMainWindow):
       armoryengine.ArmoryUtils.DEFAULT_ADDR_TYPE = \
          self.getSettingOrSetDefault('Default_ReceiveType', 'P2PKH')
 
+      # Allow creation of segwit addresses offline
+      if CLI_OPTIONS.offline:
+         armoryengine.ArmoryUtils.WITNESS = True
 
       if not self.abortLoad:
          self.acquireProcessMutex()


### PR DESCRIPTION
Make WITNESS default in the --offline mode
this does not change any policy, just enables the dialog selection of segwit address type when offline.
Otherwise, connecting to bitcoin core was the only way to use segwit addresses.